### PR TITLE
Fix string builder configuration

### DIFF
--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -41,22 +41,25 @@ class StringBuilder {
     }
 
     makeUrl(url?: string) {
-        if(url) this.printQueue.push(url);
+        if(this.config.url && url) this.printQueue.push(url);
         return this;
     }
 
     makeMethod(method?: string) {
-        if(method) this.printQueue.push(chalk.yellow(method.toUpperCase()));
+        if(this.config.method && method) this.printQueue.push(chalk.yellow(method.toUpperCase()));
         return this;
     }
 
     makeData(data: object) {
-        if(data) this.printQueue.push(JSON.stringify(data));
+        if(this.config.data && data) this.printQueue.push(JSON.stringify(data));
         return this;
     }
 
     makeStatus(status?:number, statusText?: string) {
-        if(status && statusText) this.printQueue.push(`${status}:${statusText}`);
+        const line = []
+        if(this.config.status && status) line.push(status)
+        if(this.config.statusText && statusText) line.push(statusText)
+        if(line.length) this.printQueue.push(line.join(':');
         return this;
     }
 


### PR DESCRIPTION
Currently logger does not use any config parameters, except headers.