### PR TITLE
Placing HTTP method first, then the URL

### DIFF
--- a/src/common/__test__/config.spec.js
+++ b/src/common/__test__/config.spec.js
@@ -2,8 +2,8 @@ import { getGlobalConfig, assembleBuildConfig, setGlobalConfig } from '../config
 
 test('Default globalConfig properties should be all true', () => {
     expect(getGlobalConfig()).toEqual({
-        url: true,
         method: true,
+        url: true,
         data: true,
         status: true,
     });
@@ -17,8 +17,8 @@ test('setGlobalConfig should set config. getGlobalConfig should return globalCon
 
     setGlobalConfig(globalConfig);
     expect(getGlobalConfig()).toEqual({
-        url: false,
         method: true,
+        url: false,
         data: true,
         status: true,
     });
@@ -38,8 +38,8 @@ test('assembleBuildConfig should return merged with globalConfig object.', () =>
 
     expect(buildConfig).toEqual({
         dateFormat: 'hh:mm:ss',
-        url: true,
         method: true,
+        url: true,
         data: false,
         status: true,
     });

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,8 +1,8 @@
 import { ErrorLogConfig, GlobalLogConfig, RequestLogConfig, ResponseLogConfig } from './types';
 
 let globalConfig: GlobalLogConfig = {
-    url: true,
     method: true,
+    url: true,
     data: true,
     status: true,
 };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -6,8 +6,8 @@ export interface CommonConfig {
 
 export interface GlobalLogConfig extends CommonConfig {
     data?: boolean,
-    url?: boolean,
     method?: boolean,
+    url?: boolean,
     status?: boolean,
     statusText?: boolean,
     code?: boolean,
@@ -15,8 +15,8 @@ export interface GlobalLogConfig extends CommonConfig {
 
 export interface RequestLogConfig extends CommonConfig {
     data?: boolean,
-    url?: boolean,
     method?: boolean,
+    url?: boolean,
 }
 
 export interface ResponseLogConfig extends CommonConfig {

--- a/src/logger/__test__/error.spec.js
+++ b/src/logger/__test__/error.spec.js
@@ -7,8 +7,8 @@ jest.mock('../../common/print');
 const axiosError = {
     code: 500,
     config: {
-        url: 'https://github.com/hg-pyun',
         method: 'GET',
+        url: 'https://github.com/hg-pyun',
     },
     response: {
         data: 'dummy data',
@@ -37,8 +37,8 @@ test('if config is undefined, logger make default log', () => {
     errorLoggerWithoutPromise(axiosError);
     expect(printLog).toHaveBeenCalled();
     expect(printLog).toBeCalledWith(expect.stringContaining('[Axios][Error]'));
-    expect(printLog).toBeCalledWith(expect.stringContaining(url));
     expect(printLog).toBeCalledWith(expect.stringContaining(method));
+    expect(printLog).toBeCalledWith(expect.stringContaining(url));
     expect(printLog).toBeCalledWith(expect.stringContaining(`${status}:${statusText}`));
     expect(printLog).toBeCalledWith(expect.stringContaining(data));
 });

--- a/src/logger/__test__/request.spec.js
+++ b/src/logger/__test__/request.spec.js
@@ -8,8 +8,8 @@ const axiosRequestConfig = {
         id: 1,
         text: 'this is dummy log',
     },
-    url: 'https://github.com/hg-pyun',
     method: 'GET',
+    url: 'https://github.com/hg-pyun',
 };
 
 beforeEach(() => {
@@ -26,8 +26,8 @@ test('if config is undefined, logger make default log', () => {
     requestLogger(axiosRequestConfig);
     expect(printLog).toHaveBeenCalled();
     expect(printLog).toBeCalledWith(expect.stringContaining('[Axios][Request]'));
-    expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.url));
     expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.method));
+    expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.url));
     expect(printLog).toBeCalledWith(expect.stringContaining(JSON.stringify(axiosRequestConfig.data)));
 });
 

--- a/src/logger/__test__/response.spec.js
+++ b/src/logger/__test__/response.spec.js
@@ -35,8 +35,8 @@ test('if config is undefined, logger make default log', () => {
     responseLogger(axiosResponse);
     expect(printLog).toHaveBeenCalled();
     expect(printLog).toBeCalledWith(expect.stringContaining('[Axios][Response]'));
-    expect(printLog).toBeCalledWith(expect.stringContaining(url));
     expect(printLog).toBeCalledWith(expect.stringContaining(method));
+    expect(printLog).toBeCalledWith(expect.stringContaining(url));
     expect(printLog).toBeCalledWith(expect.stringContaining(`${status}:${statusText}`));
     expect(printLog).toBeCalledWith(expect.stringContaining(data));
 });

--- a/src/logger/error.ts
+++ b/src/logger/error.ts
@@ -6,10 +6,10 @@ import { printLog } from '../common/print';
 
 function errorLoggerWithoutPromise(error: AxiosError, config?: ErrorLogConfig) {
 
-    const {config: {url, method}, response} = error;
+    const {config: { method, url }, response} = error;
 
     let status, statusText, data, headers;
-    if(response){
+    if (response) {
         status = response.status;
         statusText = response.statusText;
         data = response.data;
@@ -22,8 +22,8 @@ function errorLoggerWithoutPromise(error: AxiosError, config?: ErrorLogConfig) {
     const log = stringBuilder
         .makeLogTypeWithPrefix('Error')
         .makeDateFormat(new Date())
-        .makeUrl(url)
         .makeMethod(method)
+        .makeUrl(url)
         .makeStatus(status, statusText)
         .makeHeader(headers)
         .makeData(data)

--- a/src/logger/request.ts
+++ b/src/logger/request.ts
@@ -13,8 +13,8 @@ function requestLogger(request: AxiosRequestConfig, config?: RequestLogConfig) {
     const log = stringBuilder
         .makeLogTypeWithPrefix('Request')
         .makeDateFormat(new Date())
-        .makeUrl(url)
         .makeMethod(method)
+        .makeUrl(url)
         .makeHeader(headers)
         .makeData(data)
         .build();

--- a/src/logger/response.ts
+++ b/src/logger/response.ts
@@ -12,8 +12,8 @@ function responseLogger(response: AxiosResponse, config?: ResponseLogConfig) {
     const log = stringBuilder
         .makeLogTypeWithPrefix('Response')
         .makeDateFormat(new Date())
-        .makeUrl(url)
         .makeMethod(method)
+        .makeUrl(url)
         .makeStatus(status, statusText)
         .makeHeader(headers)
         .makeData(data)


### PR DESCRIPTION
The most standard way in REST is to reference first the method, then the URL. I'm changing that for the three kind of interceptors + kept the same ordering in all references of those two fields across the codebase. Hope this helps!

This relates to: https://github.com/hg-pyun/axios-logger/issues/60