### PR TITLE
Allow for no timestamp being appended

### DIFF
--- a/src/common/__test__/string-builder.spec.js
+++ b/src/common/__test__/string-builder.spec.js
@@ -18,6 +18,16 @@ test('makeDateFormat should add date', () => {
     expect(result).toContain(date.getFullYear());
 });
 
+test('makeDateFormat with dateFormat = false, does not add the timestamp', () => {
+    const sb = new StringBuilder({
+        dateFormat: false,
+    });
+    const date = new Date();
+    const result = sb.makeDateFormat(date).build();
+
+    expect(result).toBe('');
+});
+
 test('makeHeaders should add headers', () => {
     const sb = new StringBuilder({
         headers: true,

--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -20,9 +20,12 @@ class StringBuilder {
     }
 
     makeDateFormat(date: Date) {
-        // @ts-ignore
-        const dateFormat = dateformat(date, this.config.dateFormat || 'isoDateTime');
-        this.printQueue.push(dateFormat);
+        // allow for opting-out of adding the timestamp (as most loggers already add this)
+        if (this.config.dateFormat !== false) {
+            // @ts-ignore
+            const dateFormat = dateformat(date, this.config.dateFormat || 'isoDateTime');
+            this.printQueue.push(dateFormat);
+        }
         return this;
     }
 


### PR DESCRIPTION
The documentation states that `false` is a valid value for the `dateFormat` global config param. That usually suggests that passing `false` means "do not add this field" but in this case, the code said otherwise, it meant: "use ISO".

Since most loggers nowadays (including `console.log`!) already add a timestamp to the log line, there has to be a way to opt-out of this field, to avoid repetition.

Example:

**Before:**
```
2020-08-11T21:25:35.736Z	90142447-1486-1b56-34e1-68e1b1439670	INFO	[Response] 2020-08-11T21:25:35+0000 https://example.com/api/meters/123 GET
```

**After:**
```
2020-08-11T21:25:35.736Z	90142447-1486-1b56-34e1-68e1b1439670	INFO	[Response] https://example.com/api/meters/123 GET
```