### PR TITLE
Add log config into error logger with a promise

### DIFF
--- a/src/logger/error.ts
+++ b/src/logger/error.ts
@@ -34,8 +34,8 @@ function errorLoggerWithoutPromise(error: AxiosError, config?: ErrorLogConfig) {
     return error;
 }
 
-function errorLogger(error: AxiosError) {
-    return Promise.reject(errorLoggerWithoutPromise(error));
+function errorLogger(error: AxiosError, config?: ErrorLogConfig) {
+    return Promise.reject(errorLoggerWithoutPromise(error, config));
 }
 
 export { errorLogger, errorLoggerWithoutPromise };


### PR DESCRIPTION
Fixes #72 

Reasoning:
This is the only method that is exported in `index.ts` from the file. Every other loggers support config as the second argument.