### PR TITLE
docs: update defaults in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,18 @@ instance.interceptors.request.use((request) => {
 
 #### Enable config list
 
-| Property     | Type                                                                | Default                    | Description                                                                                                                                    |
-| ------------ | ------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `method`     | boolean                                                             | `true`                     | Whether to include HTTP method or not.                                                                                                         |
-| `url`        | boolean                                                             | `true`                     | Whether to include the URL or not.                                                                                                             |
-| `params`     | boolean                                                             | `false`                    | Whether to include the URL params or not.                                                                                                      |
-| `data`       | boolean                                                             | `true`                     | Whether to include request/response data or not.                                                                                               |
-| `status`     | boolean                                                             | `true`                     | Whether to include response statuses or not.                                                                                                   |
-| `headers`    | boolean                                                             | `false`                    | Whether to include HTTP headers or not.                                                                                                        |
-| `prefixText` | string \| `false`                                                   | `'Axios'`                  | `false` => no prefix, otherwise, customize the prefix wanted.                                                                                  |
-| `dateFormat` | [dateformat](https://github.com/felixge/node-dateformat) \| `false` | `new Date().toISOString()` | `false` => no timestamp, otherwise, customize its format                                                                                       |
-| `logger`     | function<string, any>                                               | `console.log`              | Allows users to customize the logger function to be used. e.g. Winston's `logger.info` could be leveraged, like this: `logger.info.bind(this)` |
+| Property     | Type                                                                | Default       | Description                                                                                                                                    |
+| ------------ | ------------------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `method`     | boolean                                                             | `true`        | Whether to include HTTP method or not.                                                                                                         |
+| `url`        | boolean                                                             | `true`        | Whether to include the URL or not.                                                                                                             |
+| `params`     | boolean                                                             | `false`       | Whether to include the URL params or not.                                                                                                      |
+| `data`       | boolean                                                             | `true`        | Whether to include request/response data or not.                                                                                               |
+| `status`     | boolean                                                             | `true`        | Whether to include response statuses or not.                                                                                                   |
+| `statusText` | boolean                                                             | `true`        | Whether to include response status text or not.                                                                                                |
+| `headers`    | boolean                                                             | `false`       | Whether to include HTTP headers or not.                                                                                                        |
+| `prefixText` | string \| `false`                                                   | `'Axios'`     | `false` => no prefix, otherwise, customize the prefix wanted.                                                                                  |
+| `dateFormat` | [dateformat](https://github.com/felixge/node-dateformat) \| `false` | `false`       | `false` => no timestamp, otherwise, customize its format                                                                                       |
+| `logger`     | function<string, any>                                               | `console.log` | Allows users to customize the logger function to be used. e.g. Winston's `logger.info` could be leveraged, like this: `logger.info.bind(this)` |
 
 ## CONTRIBUTE
 


### PR DESCRIPTION
The default for dateFormat is `false`.
Add missing `statusText` and its default value.