### PR TITLE
fix(error): add missing properties to error logger type config

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -28,4 +28,6 @@ export interface ResponseLogConfig extends CommonConfig {
 
 export interface ErrorLogConfig extends CommonConfig {
     data?: boolean,
+    status?: boolean,
+    statusText?: boolean,
 }


### PR DESCRIPTION
status and statusText are used in the error logger.