### PR TITLE
fix(error): make sure error.config is defined in the errorLogger

### DIFF
--- a/src/logger/__test__/error.spec.js
+++ b/src/logger/__test__/error.spec.js
@@ -28,6 +28,14 @@ test('response should be return immutable axiosError', () => {
     expect(mockLogger).toReturnWith(axiosError);
 });
 
+test('if erorr.config is undefined, return original error', () => {
+    const error = new Error('Unexpected error');
+
+    const mockLogger = jest.fn(errorLoggerWithoutPromise);
+    mockLogger(error);
+    expect(mockLogger).toReturnWith(error);
+});
+
 test('if config is undefined, logger make default log', () => {
     const {
         config: { url, method },

--- a/src/logger/error.ts
+++ b/src/logger/error.ts
@@ -4,6 +4,9 @@ import { assembleBuildConfig } from '../common/config';
 import StringBuilder from '../common/string-builder';
 
 function errorLoggerWithoutPromise(error: AxiosError, config: ErrorLogConfig = {}) {
+    if (!error.config) {
+        return error
+    }
 
     const {config: { method, baseURL, params, url }, response} = error;
 


### PR DESCRIPTION
Sometimes, axios throws an error without `error.config`, this makes sure
we don’t destructure an undefined property.

Related: https://github.com/axios/axios/pull/4665
Fix #94