### PR TITLE
fix(error): update errorLogger return type

### DIFF
--- a/src/logger/error.ts
+++ b/src/logger/error.ts
@@ -35,7 +35,7 @@ function errorLoggerWithoutPromise(error: AxiosError, config: ErrorLogConfig = {
 }
 
 function errorLogger(error: AxiosError, config?: ErrorLogConfig) {
-    return Promise.reject(errorLoggerWithoutPromise(error, config));
+    return Promise.reject<AxiosError>(errorLoggerWithoutPromise(error, config));
 }
 
 export { errorLogger, errorLoggerWithoutPromise };


### PR DESCRIPTION
By default Promise.reject returns `Promise<never>`.