### PR TITLE
adding traceId and a more standardized format

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ instance.interceptors.request.use((request) => {
 | `prefixText` | string \| `false`                                                   | `'Axios'`     | `false` => no prefix, otherwise, customize the prefix wanted.                                                                                  |
 | `dateFormat` | [dateformat](https://github.com/felixge/node-dateformat) \| `false` | `false`       | `false` => no timestamp, otherwise, customize its format                                                                                       |
 | `logger`     | function<string, any>                                               | `console.log` | Allows users to customize the logger function to be used. e.g. Winston's `logger.info` could be leveraged, like this: `logger.info.bind(this)` |
+| `traceId`    | string \| `false`                                                   | `false`       | Allows users to add a string to be used as a traceable id between request/response (or a sequence of them).                                    |
 
 ## CONTRIBUTE
 

--- a/src/common/__test__/config.spec.js
+++ b/src/common/__test__/config.spec.js
@@ -15,6 +15,7 @@ test('Default globalConfig properties should be equal to default values', () => 
         dateFormat: false,
         prefixText: DEFAULT_PREFIX,
         headers: false,
+        traceId: false,
     });
 });
 
@@ -37,6 +38,7 @@ test('setGlobalConfig should set config. getGlobalConfig should return globalCon
         dateFormat: false,
         prefixText: DEFAULT_PREFIX,
         headers: false,
+        traceId: false,
     });
 });
 
@@ -64,5 +66,6 @@ test('assembleBuildConfig should return merged with globalConfig object.', () =>
         dateFormat: 'hh:mm:ss',
         prefixText: DEFAULT_PREFIX,
         headers: false,
+        traceId: false,
     });
 });

--- a/src/common/__test__/string-builder.spec.js
+++ b/src/common/__test__/string-builder.spec.js
@@ -1,5 +1,6 @@
 import StringBuilder from '../string-builder';
 import { getGlobalConfig } from '../config';
+import chalk from 'chalk';
 
 test('makeLogTypeWithPrefix should add prefix text', () => {
     const sb = new StringBuilder(getGlobalConfig());
@@ -84,4 +85,17 @@ test('makeData should not stringify data if configured not to', () => {
     const sb = new StringBuilder(config);
     const result = sb.makeData(a).build();
     expect(result).toEqual('');
+});
+
+test('makeTraceId should add a string if configured', () => {
+    const testId = '1324567890987654321';
+    const config = {
+        ...getGlobalConfig(),
+        traceId: testId,
+    };
+
+    const sb = new StringBuilder(config);
+    const result = sb.makeTraceId().build();
+
+    expect(result).toContain(`[${chalk.blue(testId)}]`);
 });

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -11,6 +11,7 @@ let globalConfig: Required<GlobalLogConfig> = {
     prefixText: 'Axios',
     dateFormat: false,
     headers: false,
+    traceId: false,
 };
 
 function getGlobalConfig() {

--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -4,18 +4,20 @@ import chalk from 'chalk';
 
 class StringBuilder {
     private config: GlobalLogConfig;
+    private lineHeader: Array<string>;
     private printQueue: Array<string>;
     private filteredHeaderList: Array<String>;
 
     constructor(config: GlobalLogConfig) {
         this.config = config;
+        this.lineHeader = [];
         this.printQueue = [];
         this.filteredHeaderList = ['common', 'delete', 'get', 'head', 'post', 'put', 'patch', 'content-type', 'content-length', 'vary', 'date', 'connection', 'content-security-policy'];
     }
 
     makeLogTypeWithPrefix(logType: string) {
         const prefix = this.config.prefixText === false ? `[${logType}]` : `[${this.config.prefixText || 'Axios'}][${logType}]`;
-        this.printQueue.push(chalk.green(prefix));
+        this.lineHeader.push(chalk.green(prefix));
         return this;
     }
 
@@ -24,7 +26,14 @@ class StringBuilder {
         if (this.config.dateFormat !== false) {
             // @ts-ignore
             const dateFormat = dateformat(date, this.config.dateFormat || 'isoDateTime');
-            this.printQueue.push(dateFormat);
+            this.lineHeader.push(`[${dateFormat}]`);
+        }
+        return this;
+    }
+
+    makeTraceId() {
+        if (this.config.traceId !== false) {
+            this.lineHeader.push(`[${chalk.blue(this.config.traceId)}]`);
         }
         return this;
     }
@@ -76,8 +85,13 @@ class StringBuilder {
         return this;
     }
 
+    buildLineHeader() {
+        return this.lineHeader.join();
+    }
+
     build() {
-        return this.printQueue.join(' ');
+        const lineStart = this.buildLineHeader();
+        return `${lineStart} ` + this.printQueue.join(' ');
     }
 
     /**

--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -90,8 +90,7 @@ class StringBuilder {
     }
 
     build() {
-        const lineStart = this.buildLineHeader();
-        return `${lineStart} ` + this.printQueue.join(' ');
+            return this.buildLineHeader() ? `${this.buildLineHeader()} ` + this.printQueue.join(' ') : this.printQueue.join(' ');
     }
 
     /**

--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -86,7 +86,7 @@ class StringBuilder {
     }
 
     buildLineHeader() {
-        return this.lineHeader.join();
+        return this.lineHeader.join('');
     }
 
     build() {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,18 +12,21 @@ export interface GlobalLogConfig extends CommonConfig {
     url?: boolean,
     status?: boolean,
     statusText?: boolean,
+    traceId?: string | boolean,
 }
 
 export interface RequestLogConfig extends CommonConfig {
     data?: boolean,
     method?: boolean,
     url?: boolean,
+    traceId?: string | boolean,
 }
 
 export interface ResponseLogConfig extends CommonConfig {
     data?: boolean,
     status?: boolean,
     statusText?: boolean,
+    traceId?: string | boolean,
 }
 
 export interface ErrorLogConfig extends CommonConfig {

--- a/src/logger/__test__/request.spec.js
+++ b/src/logger/__test__/request.spec.js
@@ -1,4 +1,5 @@
 import { requestLogger, setGlobalConfig } from '../../index';
+import chalk from 'chalk';
 
 const printLog = jest.fn(() => {});
 
@@ -90,4 +91,33 @@ test('if baseUrl is taken into consideration', () => {
     requestLogger({ ...axiosRequestConfig, baseURL: 'https://github.com/', url: '/hg-pyun' });
     expect(printLog).toHaveBeenCalled();
     expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.url));
+});
+
+test('test a full request', () => {
+    const globalConfig = {
+        prefixText: 'TEST',
+        dateFormat: 'dd-mm-yyyy HH:MM:ss.l',
+        status: true,
+        method: true,
+        headers: true,
+        data: true,
+        traceId: '1324567890987654321',
+    };
+
+    setGlobalConfig(globalConfig);
+    requestLogger({ ...axiosRequestConfig, baseURL: 'https://github.com/', url: '/hg-pyun' });
+    expect(printLog).toHaveBeenCalled();
+    expect(printLog).toBeCalledWith(expect.stringContaining('[TEST]'));
+    expect(printLog).toBeCalledWith(expect.stringContaining('[Request]'));
+    expect(printLog).toBeCalledWith(expect.stringContaining(`[${chalk.blue('1324567890987654321')}]`));
+    expect(printLog).toBeCalledWith(
+        expect.stringMatching(
+            new RegExp(
+                /\[[01]?\d-(([0-2]?\d)|([3][01]))-((199\d)|([2-9]\d{3})) ([0-1]\d|[2][0-3]):([0-5]\d):([0-5]\d).(\d{0,3})\]/
+            )
+        )
+    );
+    expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.method));
+    expect(printLog).toBeCalledWith(expect.stringContaining(axiosRequestConfig.url));
+    expect(printLog).toBeCalledWith(expect.stringContaining(JSON.stringify(axiosRequestConfig.data)));
 });

--- a/src/logger/__test__/response.spec.js
+++ b/src/logger/__test__/response.spec.js
@@ -1,4 +1,5 @@
 import { responseLogger, setGlobalConfig } from '../../index';
+import chalk from 'chalk';
 
 const printLog = jest.fn(() => {});
 
@@ -103,4 +104,41 @@ test('if baseUrl is taken into consideration', () => {
     });
     expect(printLog).toHaveBeenCalled();
     expect(printLog).toBeCalledWith(expect.stringContaining(axiosResponse.config.url));
+});
+
+test('test a full response', () => {
+    const globalConfig = {
+        prefixText: 'TEST',
+        dateFormat: 'dd-mm-yyyy HH:MM:ss.l',
+        status: true,
+        method: true,
+        headers: true,
+        data: true,
+        traceId: '1324567890987654321',
+    };
+
+    const {
+        status,
+        statusText,
+        data,
+        config: { url, method },
+    } = axiosResponse;
+
+    setGlobalConfig(globalConfig);
+    responseLogger(axiosResponse);
+    expect(printLog).toHaveBeenCalled();
+    expect(printLog).toBeCalledWith(expect.stringContaining('[TEST]'));
+    expect(printLog).toBeCalledWith(expect.stringContaining('[Response]'));
+    expect(printLog).toBeCalledWith(expect.stringContaining(`[${chalk.blue('1324567890987654321')}]`));
+    expect(printLog).toBeCalledWith(
+        expect.stringMatching(
+            new RegExp(
+                /\[[01]?\d-(([0-2]?\d)|([3][01]))-((199\d)|([2-9]\d{3})) ([0-1]\d|[2][0-3]):([0-5]\d):([0-5]\d).(\d{0,3})\]/
+            )
+        )
+    );
+    expect(printLog).toBeCalledWith(expect.stringContaining(method));
+    expect(printLog).toBeCalledWith(expect.stringContaining(url));
+    expect(printLog).toBeCalledWith(expect.stringContaining(`${status}:${statusText}`));
+    expect(printLog).toBeCalledWith(expect.stringContaining(data));
 });

--- a/src/logger/error.ts
+++ b/src/logger/error.ts
@@ -24,6 +24,7 @@ function errorLoggerWithoutPromise(error: AxiosError, config: ErrorLogConfig = {
     const log = stringBuilder
         .makeLogTypeWithPrefix('Error')
         .makeDateFormat(new Date())
+        .makeTraceId()
         .makeMethod(method)
         .makeUrl(url, baseURL)
         .makeParams(params)

--- a/src/logger/request.ts
+++ b/src/logger/request.ts
@@ -12,6 +12,7 @@ function requestLogger(request: AxiosRequestConfig, config: RequestLogConfig = {
     const log = stringBuilder
         .makeLogTypeWithPrefix('Request')
         .makeDateFormat(new Date())
+        .makeTraceId()
         .makeMethod(method)
         .makeUrl(url, baseURL)
         .makeParams(params)

--- a/src/logger/response.ts
+++ b/src/logger/response.ts
@@ -12,6 +12,7 @@ function responseLogger(response: AxiosResponse, config: ResponseLogConfig = {})
     const log = stringBuilder
         .makeLogTypeWithPrefix('Response')
         .makeDateFormat(new Date())
+        .makeTraceId()
         .makeMethod(method)
         .makeUrl(url, baseURL)
         .makeParams(params)


### PR DESCRIPTION
- I've added the possibility to add a traceId to the log (globally or separate on request/response/error)
- Also change a little bit the format to make it more standardized:
`[TEST][Request][05-04-2023 01:13:38.355][1324567890987654321] GET https://github.com/hg-pyun {\"id\":1,\"text\":\"this is dummy log\"}`
- aligned the tests

<!-- gk-ai-analysis-start:3717dec695bb9a10f28d13e496e5ad949e631775 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiYWRkaW5nIHRyYWNlSWQgYW5kIGEgbW9yZSBzdGFuZGFyZGl6ZWQgZm9ybWF0IHVwZGF0ZXMgMTEgZmlsZShzKSB3aXRoICsxMDkvLTMgbGluZSBjaGFuZ2VzIGZyb20gdHJhY2VJZF9hbmRfZm9ybWF0aW5nIGludG8gbWFzdGVyLiBNb3N0IGNoYW5nZXMgYXJlIGNvbmNlbnRyYXRlZCBpbiBzcmMvbG9nZ2VyL19fdGVzdF9fL3Jlc3BvbnNlLnNwZWMuanMsIHNyYy9sb2dnZXIvX190ZXN0X18vcmVxdWVzdC5zcGVjLmpzLCBzcmMvY29tbW9uL3N0cmluZy1idWlsZGVyLnRzLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlBSIHNjb3BlIGFuZCBjaGFuZ2Ugdm9sdW1lIiwiZGVzY3JpcHRpb24iOiJUaGUgUFIgY2hhbmdlcyAxMSBmaWxlKHMpLCBhZGRpbmcgMTA5IGxpbmVzIGFuZCBkZWxldGluZyAzIGxpbmVzLiIsInNldmVyaXR5IjoibWVkaXVtIn0seyJ0aXRsZSI6IlVwZGF0ZWQgc3JjL2xvZ2dlci9fX3Rlc3RfXy9yZXNwb25zZS5zcGVjLmpzIiwiZGVzY3JpcHRpb24iOiJzcmMvbG9nZ2VyL19fdGVzdF9fL3Jlc3BvbnNlLnNwZWMuanMgaW5jbHVkZXMgMzggYWRkaXRpb25zIGFuZCAwIGRlbGV0aW9ucy4iLCJmaWxlUGF0aCI6InNyYy9sb2dnZXIvX190ZXN0X18vcmVzcG9uc2Uuc3BlYy5qcyIsInNldmVyaXR5IjoibWVkaXVtIn0seyJ0aXRsZSI6IlVwZGF0ZWQgc3JjL2xvZ2dlci9fX3Rlc3RfXy9yZXF1ZXN0LnNwZWMuanMiLCJkZXNjcmlwdGlvbiI6InNyYy9sb2dnZXIvX190ZXN0X18vcmVxdWVzdC5zcGVjLmpzIGluY2x1ZGVzIDMwIGFkZGl0aW9ucyBhbmQgMCBkZWxldGlvbnMuIiwiZmlsZVBhdGgiOiJzcmMvbG9nZ2VyL19fdGVzdF9fL3JlcXVlc3Quc3BlYy5qcyIsInNldmVyaXR5IjoibWVkaXVtIn1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:3717dec695bb9a10f28d13e496e5ad949e631775 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/hg-pyun/axios-logger/pull/127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->