### PR TITLE
fix: ignore the base URL when the relative one is a complete URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 node_modules/
 lib/
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "axios-logger",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "axios-logger",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",

--- a/src/common/__test__/string-builder.spec.js
+++ b/src/common/__test__/string-builder.spec.js
@@ -85,3 +85,38 @@ test('makeData should not stringify data if configured not to', () => {
     const result = sb.makeData(a).build();
     expect(result).toEqual('');
 });
+
+test('combineURLs should combine the base URL with the relative URL', () => {
+    const sb = new StringBuilder(getGlobalConfig());
+    const result = sb.combineURLs('https://github.com', '/users/hg-pyun');
+
+    expect(result).toBe('https://github.com/users/hg-pyun');
+});
+
+test(`combineURLs should not combine the base and relative URL's if the relative one is a complete URL`, () => {
+    const sb = new StringBuilder(getGlobalConfig());
+    const result = sb.combineURLs('https://github.com', 'https://github.com/users/hg-pyun');
+
+    expect(result).toBe('https://github.com/users/hg-pyun');
+});
+
+test('combineURLs should return the base URL when the relative URL is empty', () => {
+    const sb = new StringBuilder(getGlobalConfig());
+    const result = sb.combineURLs('https://github.com', '');
+
+    expect(result).toBe('https://github.com');
+});
+
+test('combineURLs should return the relative URL when the base URL is empty', () => {
+    const sb = new StringBuilder(getGlobalConfig());
+    const result = sb.combineURLs('', 'https://github.com/users/hg-pyun');
+
+    expect(result).toBe('https://github.com/users/hg-pyun');
+});
+
+test('combineURLs should return the relative URL when the base URL is undefined', () => {
+    const sb = new StringBuilder(getGlobalConfig());
+    const result = sb.combineURLs(undefined, 'https://github.com/users/hg-pyun');
+
+    expect(result).toBe('https://github.com/users/hg-pyun');
+});

--- a/src/common/string-builder.ts
+++ b/src/common/string-builder.ts
@@ -80,15 +80,9 @@ class StringBuilder {
         return this.printQueue.join(' ');
     }
 
-    /**
-     * Helper imported from Axios library
-     * @see https://github.com/axios/axios/blob/d99d5faac29899eba68ce671e6b3cbc9832e9ad8/lib/helpers/combineURLs.js
-     * */
-    combineURLs(baseURL: string, relativeURL?: string): string {
-        return relativeURL
-            ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
-            : baseURL;
-    };
+   combineURLs(baseURL: string, relativeURL?: string): string {
+        return relativeURL ? new URL(relativeURL, baseURL || undefined).toString() : baseURL;
+    }
 }
 
 export default StringBuilder;


### PR DESCRIPTION
Solves the bug reported on issue #101. The method `combineURLs` was rewritten, and tests were added to it.