### PR TITLE
use the updated typing for the request parameter of the request interceptor

### DIFF
--- a/src/logger/request.ts
+++ b/src/logger/request.ts
@@ -1,9 +1,9 @@
-import { AxiosRequestConfig } from 'axios';
-import { RequestLogConfig } from '../common/types';
-import { assembleBuildConfig } from '../common/config';
-import StringBuilder from '../common/string-builder';
+import { InternalAxiosRequestConfig } from 'axios'
+import { assembleBuildConfig } from '../common/config'
+import StringBuilder from '../common/string-builder'
+import { RequestLogConfig } from '../common/types'
 
-function requestLogger(request: AxiosRequestConfig, config: RequestLogConfig = {}) {
+function requestLogger(request: InternalAxiosRequestConfig, config: RequestLogConfig = {}) {
 
     const {baseURL, url, params, method, data, headers} = request;
     const buildConfig = assembleBuildConfig(config);


### PR DESCRIPTION
Axios changed the typing of the request parameter on request interceptors. This should realign with the new typing and thus fixes #131 